### PR TITLE
feat: create shell command run_with_login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f aptible-cli.deb
 
+# Used to simplify docker run commands needing the login
+COPY run_with_login .
+
 ENTRYPOINT ["aptible"]
 CMD ["help"]

--- a/run_with_login
+++ b/run_with_login
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+: "${APTIBLE_USERNAME?Need to set environment APTIBLE_USERNAME}"
+: "${APTIBLE_PASSWORD?Need to set environment APTIBLE_PASSWORD}"
+
+aptible login --email $APTIBLE_USERNAME --password $APTIBLE_PASSWORD
+aptible "$@"


### PR DESCRIPTION
# Why?

In order to streamline the `docker run` use of this container, we add a helper shell script to avoid complex `docker run` commands from joining the login and execution of the desired Aptible CLI command.