### PR TITLE
fix: add workdir for run_with_login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:8.10
+WORKDIR /usr/src
 
 COPY ssh_config /etc/ssh/ssh_config
 


### PR DESCRIPTION
# Why?

In order to run `run_with_login` it requires the working directory to be set. Otherwise, the entry point command will fail with file not found